### PR TITLE
deps: batch Dependabot updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # GitHub integration modules:
-PyGithub==2.8.1
+PyGithub==2.9.0
 GitPython==3.1.46
 
 # Request making and response parsing modules:


### PR DESCRIPTION
## Summary
- bump `PyGithub` from `2.8.1` to `2.9.0`
- supersede the open Dependabot PR for the same update with one automation-owned batch branch
- keep the code diff scoped to `requirements.txt`

## Validation
- `source .venv312/bin/activate && python -m pytest` ✅
- `source .venv312/bin/activate && python -m flake8 sources tests github_stats.py --count` ⚠️ fails on pre-existing repo lint debt unrelated to this bump
- `source .venv312/bin/activate && python -m black --check sources tests github_stats.py` ⚠️ fails on pre-existing repo formatting debt unrelated to this bump
- `source .venv312/bin/activate && pre-commit run --all-files` ⚠️ security hooks passed; `end-of-file-fixer` rewrote unrelated files, so those changes were left out of the commit

## Risk review
- PyGithub 2.9.0 adds lazy-object behavior and drops Python 3.8 support upstream
- this repository already targets `python-version: 3.x` in GitHub Actions and the bump passed the local pytest suite under Python 3.12
- no additional updates were open to include in this batch

## Superseded PRs
- closes #78 after merge