### PR TITLE
Batch Dependabot cryptography update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ flake8==7.3.0
 black==26.3.1
 
 # Add encryption support
-cryptography==46.0.6
+cryptography==46.0.7
 
 # Development tools
 pre-commit==4.5.1


### PR DESCRIPTION
## Summary
- Batch the open Dependabot cryptography patch bump into one reviewable PR.
- Carry the dependency from 46.0.6 to 46.0.7 to pick up the security update.

## Changes
- Updated `requirements.txt` to pin `cryptography==46.0.7`.
- Kept the change isolated to the dependency pin; no other files changed.

## Testing
- `.venv312/bin/python -m pytest -q` (40 passed)
- `git diff origin/main...HEAD --stat`