### PR TITLE
Batch Dependabot PyGithub bump

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # GitHub integration modules:
-PyGithub==2.9.0
+PyGithub==2.9.1
 GitPython==3.1.46
 
 # Request making and response parsing modules:


### PR DESCRIPTION
## Summary
- Batch the open Dependabot update for PyGithub into one verified PR
- Keep the repo current with the bugfix release 2.9.1

## Changes
- Bumped `PyGithub` from 2.9.0 to 2.9.1 in `requirements.txt`
- Left the rest of the dependency set unchanged

## Testing
- `git diff main...HEAD --stat`
- `python3 -m pip install -r requirements.txt` (failed in this environment because `humanize==4.14.0` is unavailable from the configured index)
