### PR TITLE
Batch Dependabot updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # GitHub integration modules:
 PyGithub==2.9.1
-GitPython==3.1.47
+GitPython==3.1.50
 
 # Request making and response parsing modules:
 httpx==0.28.1
@@ -10,14 +10,14 @@ humanize==4.14.0
 python-dotenv==1.2.2
 
 # Time zone handling
-pytz==2026.1.post1
+pytz==2026.2
 
 # Codestyle checking modules:
 flake8==7.3.0
-black==26.3.1
+black==26.5.1
 
 # Add encryption support
-cryptography==46.0.7
+cryptography==48.0.0
 
 # Development tools
-pre-commit==4.5.1
+pre-commit==4.6.0


### PR DESCRIPTION
## Summary
- Batch the open Dependabot Python dependency bumps into one reviewable PR
- Update `black`, `cryptography`, `GitPython`, `pre-commit`, and `pytz` together in `requirements.txt`
- Replace six bot PRs, including the duplicate GitPython bump, with one validated branch

## Changes
- Bump `black` from `26.3.1` to `26.5.1`
- Bump `cryptography` from `46.0.7` to `48.0.0`
- Bump `GitPython` from `3.1.47` to `3.1.50`
- Bump `pre-commit` from `4.5.1` to `4.6.0`
- Bump `pytz` from `2026.1.post1` to `2026.2`

## Testing
- `python3.12 -m venv venv && source venv/bin/activate`
- `pip install -r requirements.txt pytest pytest-asyncio bandit safety pip-audit`
- `pytest`
- `pre-commit run --all-files`
- `bandit -r sources github_stats.py -ll -ii`
- `safety check -r requirements.txt --full-report`

## Notes
- `flake8 sources tests github_stats.py` still fails on pre-existing repository style debt unrelated to this batch.
- `pip-audit -r requirements.txt` re-hit a local pip resolver issue for newly published versions; `pip-audit --local` on the validated venv reported toolchain-only findings (`pip`, `authlib`, `urllib3`, `idna`), while `safety check -r requirements.txt` reported zero requirement-level vulnerabilities.
