### PR TITLE
Bump Dependabot dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # GitHub integration modules:
 PyGithub==2.9.1
-GitPython==3.1.47
+GitPython==3.1.50
 
 # Request making and response parsing modules:
 httpx==0.28.1
@@ -10,14 +10,14 @@ humanize==4.14.0
 python-dotenv==1.2.2
 
 # Time zone handling
-pytz==2026.1.post1
+pytz==2026.2
 
 # Codestyle checking modules:
 flake8==7.3.0
-black==26.3.1
+black==26.5.1
 
 # Add encryption support
-cryptography==46.0.7
+cryptography==48.0.0
 
 # Development tools
-pre-commit==4.5.1
+pre-commit==4.6.0


### PR DESCRIPTION
## Summary
- Combine open Dependabot dependency bumps into a single batched PR
- Keep lockfile-independent dependency-only updates scoped to project requirements

## Changes
- Update `requirements.txt`:
  - `GitPython` `3.1.47` -> `3.1.50`
  - `pytz` `2026.1.post1` -> `2026.2`
  - `black` `26.3.1` -> `26.5.1`
  - `cryptography` `46.0.7` -> `48.0.0`
  - `pre-commit` `4.5.1` -> `4.6.0`
- No code files were changed

## Testing
- `python3 /Users/comphy-mac/.codex/plugins/cache/codex-vatsal-marketplace/jarvis/1.0.88/skills/gh-dependabot-batch-pr/scripts/collect_dependabot_updates.py --from-gh --write-json tmp/dependabot-updates.json` succeeded and captured 5 open Dependabot updates
- `python3 /Users/comphy-mac/.codex/plugins/cache/codex-vatsal-marketplace/jarvis/1.0.88/skills/gh-dependabot-batch-pr/scripts/run_repo_checks.py --require-scripts` failed: `package.json` missing (Node-based checks unavailable for this repo)
- `python3 -m pip install -r requirements.txt --upgrade` failed: `humanize==4.14.0` in repository currently has no published release on index
- `python3 -m compileall -q sources` passed

## Excluded updates
- None

## Risk notes
- `cryptography` includes a major version bump (`46.0.7` -> `48.0.0`) and was included in the batch after reviewing diff scope (no code path changes in repo)
