### PR TITLE
Fix complete commit history counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 - Prevents double-counting of commits across branches
 - Uses commit hash tracking for accurate statistics
 - Handles merge commits and branch synchronization intelligently
+- Paginates complete author-filtered branch histories
 
 📊 **Analytics Include**
 - Time of day commit patterns (Early Bird vs Night Owl)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # GitHub integration modules:
 PyGithub==2.9.1
-GitPython==3.1.50
+GitPython==3.1.57
 
 # Request making and response parsing modules:
 httpx==0.28.1

--- a/sources/graphics_list_formatter.py
+++ b/sources/graphics_list_formatter.py
@@ -6,6 +6,7 @@ from pytz import timezone, utc
 
 from .manager_file import FileManager as FM
 from .manager_environment import EnvironmentManager as EM
+from .yearly_commit_calculator import repository_key
 
 
 DAY_TIME_EMOJI = ["🌞", "🌆", "🌃", "🌙"]  # Emojis, representing different times of day.
@@ -90,10 +91,11 @@ async def make_commit_day_time_list(time_zone: str, repositories: Dict, commit_d
     total_commits = 0
 
     for repository in repositories:
-        if repository["name"] not in commit_dates.keys():
+        repo_key = repository_key(repository)
+        if repo_key not in commit_dates.keys():
             continue
 
-        for committed_date in [commit_date for branch in commit_dates[repository["name"]].values() for commit_date in branch.values()]:
+        for committed_date in [commit_date for branch in commit_dates[repo_key].values() for commit_date in branch.values()]:
             total_commits += 1
             local_date = datetime.strptime(committed_date, "%Y-%m-%dT%H:%M:%SZ")
             date = local_date.replace(tzinfo=utc).astimezone(timezone(time_zone))
@@ -107,7 +109,7 @@ async def make_commit_day_time_list(time_zone: str, repositories: Dict, commit_d
 
     # Add total commits count if enabled
     if EM.SHOW_TOTAL_COMMITS:
-        stats += f"**My Total Overall Commits: {total_commits}** \n\n"
+        stats += f"**Accessible unique commits across repository branches: {total_commits}** \n\n"
 
     if EM.SHOW_COMMIT:
         dt_names = [f"{DAY_TIME_EMOJI[i]} {FM.t(DAY_TIME_NAMES[i])}" for i in range(len(day_times))]

--- a/sources/manager_download.py
+++ b/sources/manager_download.py
@@ -1,10 +1,9 @@
 from asyncio import Task
 from hashlib import sha256
 from json import dumps
-from string import Template
 from typing import Dict, List
-import os
 from asyncio import sleep
+from copy import deepcopy
 
 from httpx import AsyncClient
 
@@ -13,6 +12,14 @@ from .manager_debug import DebugManager as DBM
 from .manager_token import TokenManager
 
 GITHUB_API_QUERIES = {
+    "user_identity": """
+query($username: String!) {
+    user(login: $username) {
+        id
+        login
+    }
+}
+""",
     "user_repository_list": """
 query($username: String!, $after: String) {
     user(login: $username) {
@@ -27,6 +34,7 @@ query($username: String!, $after: String) {
                     name
                 }
                 name
+                nameWithOwner
                 owner {
                     login
                 }
@@ -41,23 +49,27 @@ query($username: String!, $after: String) {
 }
 """,
     "repo_branch_list": """
-query($owner: String!, $name: String!) {
+query($owner: String!, $name: String!, $after: String) {
     repository(owner: $owner, name: $name) {
-        refs(first: 100, refPrefix: "refs/heads/") {
+        refs(first: 100, after: $after, refPrefix: "refs/heads/") {
             nodes {
                 name
+            }
+            pageInfo {
+                hasNextPage
+                endCursor
             }
         }
     }
 }
 """,
     "repo_commit_list": """
-query($owner: String!, $name: String!, $branch: String!) {
+query($owner: String!, $name: String!, $branch: String!, $authorId: ID!, $after: String) {
     repository(owner: $owner, name: $name) {
         ref(qualifiedName: $branch) {
             target {
                 ... on Commit {
-                    history(first: 100) {
+                    history(first: 100, after: $after, author: {id: $authorId}) {
                         nodes {
                             committedDate
                             oid
@@ -68,6 +80,10 @@ query($owner: String!, $name: String!, $branch: String!) {
                                     login
                                 }
                             }
+                        }
+                        pageInfo {
+                            hasNextPage
+                            endCursor
                         }
                     }
                 }
@@ -122,9 +138,10 @@ class DownloadManager:
             
         # Validate required variables based on query type
         required_vars = {
+            'user_identity': ['username'],
             'user_repository_list': ['username'],
             'repo_branch_list': ['owner', 'name'],
-            'repo_commit_list': ['owner', 'name', 'branch']
+            'repo_commit_list': ['owner', 'name', 'branch', 'authorId']
         }
         
         missing_vars = [var for var in required_vars[query] if var not in kwargs]
@@ -171,11 +188,14 @@ class DownloadManager:
         end_cursor = None
         retry_count = 0
         max_retries = 5
+        result = None
+        base_variables = variables.copy()
         
         while has_next_page and retry_count < max_retries:
             try:
+                request_variables = base_variables.copy()
                 if end_cursor:
-                    variables["after"] = end_cursor
+                    request_variables["after"] = end_cursor
 
                 DBM.i(f"Sending GraphQL query: {query} {'with cursor' if end_cursor else ''}")
                 
@@ -184,7 +204,7 @@ class DownloadManager:
                     "https://api.github.com/graphql",
                     json={
                         "query": query_str,
-                        "variables": variables
+                        "variables": request_variables
                     },
                     timeout=30.0  # 30 second timeout
                 )
@@ -236,14 +256,24 @@ class DownloadManager:
                 # Reset retry count on successful request    
                 retry_count = 0
                 
-                # Handle pagination for different query types
+                page_data = data["data"]
+                if query == "user_identity":
+                    return page_data
+
+                # Aggregate pages while retaining the response shapes used by
+                # the existing collectors.
                 if query == "user_repository_list":
-                    repos = data["data"]["user"]["repositories"]
-                    all_nodes.extend(repos["nodes"])
-                    has_next_page = repos["pageInfo"]["hasNextPage"]
-                    end_cursor = repos["pageInfo"]["endCursor"]
+                    connection = page_data["user"]["repositories"]
+                elif query == "repo_branch_list":
+                    connection = page_data["repository"]["refs"]
                 else:
-                    return data["data"]
+                    connection = page_data["repository"]["ref"]["target"]["history"]
+
+                if result is None:
+                    result = deepcopy(page_data)
+                all_nodes.extend(connection["nodes"])
+                has_next_page = connection["pageInfo"]["hasNextPage"]
+                end_cursor = connection["pageInfo"]["endCursor"]
                     
             except Exception as e:
                 error_msg = TokenManager.mask_token(str(e))
@@ -252,8 +282,18 @@ class DownloadManager:
                 
         if retry_count >= max_retries:
             raise Exception("Max retries exceeded for GraphQL query")
+
+        # Never return a truncated connection if pagination stopped early.
+        if has_next_page:
+            raise Exception(f"Incomplete pagination for GraphQL query: {query}")
             
-        return all_nodes if query == "user_repository_list" else data["data"]
+        if query == "user_repository_list":
+            return all_nodes
+        if query == "repo_branch_list":
+            result["repository"]["refs"]["nodes"] = all_nodes
+        elif query == "repo_commit_list":
+            result["repository"]["ref"]["target"]["history"]["nodes"] = all_nodes
+        return result
 
     @staticmethod
     async def close_remote_resources():

--- a/sources/manager_file.py
+++ b/sources/manager_file.py
@@ -12,6 +12,7 @@ import signal
 from contextlib import contextmanager
 import json
 import os
+import time
 
 from .manager_environment import EnvironmentManager as EM
 from .manager_debug import DebugManager as DBM
@@ -170,7 +171,12 @@ class FileManager:
             raise ValueError(f"Failed to write file: {str(e)}")
 
     @staticmethod
-    def cache_binary(name: str, content: Any = None, assets: bool = False) -> Optional[Any]:
+    def cache_binary(
+        name: str,
+        content: Any = None,
+        assets: bool = False,
+        max_age_seconds: Optional[int] = None,
+    ) -> Optional[Any]:
         """Enhanced secure cache with better encryption and token protection"""
         try:
             # Validate filename
@@ -215,6 +221,11 @@ class FileManager:
                 return None
 
             try:
+                if max_age_seconds is not None:
+                    age_seconds = time.time() - os.path.getmtime(filepath)
+                    if age_seconds > max_age_seconds:
+                        return None
+
                 with open(filepath, 'rb') as f:
                     encrypted_data = f.read()
                 try:

--- a/sources/yearly_commit_calculator.py
+++ b/sources/yearly_commit_calculator.py
@@ -2,16 +2,18 @@ from asyncio import sleep
 from json import dumps
 from re import search
 from datetime import datetime, timedelta
-from typing import Dict, Tuple, List
+from typing import Dict, Tuple, List, Set
 import os
 from hashlib import sha256
 
 from .manager_download import DownloadManager as DM
 from .manager_environment import EnvironmentManager as EM
-from .manager_github import GitHubManager as GHM
 from .manager_file import FileManager as FM
 from .manager_debug import DebugManager as DBM
 from .manager_token import TokenManager
+
+COMMIT_CACHE_MAX_AGE_SECONDS = 24 * 60 * 60
+CACHE_SCHEMA_VERSION = 2
 
 
 def ensure_cache_dir():
@@ -34,11 +36,18 @@ async def calculate_commit_data(repositories: List[Dict], target_username: str) 
     DBM.i("Calculating commit data...")
     
     # Create cache filename with username (using hash for safety)
-    cache_filename = f"commits_{sha256(target_username.encode()).hexdigest()}.json"
+    cache_filename = (
+        f"commits_v{CACHE_SCHEMA_VERSION}_"
+        f"{sha256(target_username.encode()).hexdigest()}.json"
+    )
     
     # Try to load cached data if it's recent enough
     try:
-        cached_data = FM.cache_binary(cache_filename, assets=True)
+        cached_data = FM.cache_binary(
+            cache_filename,
+            assets=True,
+            max_age_seconds=COMMIT_CACHE_MAX_AGE_SECONDS,
+        )
         if cached_data is not None:
             yearly_data, date_data = cached_data
             
@@ -58,11 +67,22 @@ async def calculate_commit_data(repositories: List[Dict], target_username: str) 
     DBM.i("Fetching fresh commit data...")
     yearly_data = dict()
     date_data = dict()
+    seen_commit_oids: Set[str] = set()
+
+    identity = await DM.get_remote_graphql("user_identity", username=target_username)
+    author_id = identity["user"]["id"]
     
     # Process repositories one by one
     for i, repo in enumerate(repositories, 1):
         DBM.i(f"\t{i}/{len(repositories)} Retrieving repo: {repo['owner']['login']}/{repo['name']}")
-        await update_data_with_commit_stats(repo, yearly_data, date_data, target_username)
+        await update_data_with_commit_stats(
+            repo,
+            yearly_data,
+            date_data,
+            target_username,
+            author_id,
+            seen_commit_oids,
+        )
     
     DBM.i("Commit data calculated!")
     
@@ -73,7 +93,22 @@ async def calculate_commit_data(repositories: List[Dict], target_username: str) 
     return yearly_data, date_data
 
 
-async def update_data_with_commit_stats(repo_details: Dict, yearly_data: Dict, date_data: Dict, target_username: str):
+def repository_key(repo_details: Dict) -> str:
+    """Return a collision-safe repository identifier."""
+    return repo_details.get(
+        "nameWithOwner",
+        f"{repo_details['owner']['login']}/{repo_details['name']}",
+    )
+
+
+async def update_data_with_commit_stats(
+    repo_details: Dict,
+    yearly_data: Dict,
+    date_data: Dict,
+    target_username: str,
+    author_id: str,
+    seen_commit_oids: Set[str],
+):
     """
     Updates yearly commit data with commits from given repository.
     Skips update if the commit isn't related to any repository.
@@ -93,13 +128,13 @@ async def update_data_with_commit_stats(repo_details: Dict, yearly_data: Dict, d
         # Use TokenManager to mask any sensitive info in error message
         error_msg = TokenManager.mask_token(str(e))
         DBM.w(f"\t\tError fetching branches: {error_msg}")
-        return
+        raise
     
     # Extract branch names from the response structure
     branches = [branch["name"] for branch in branches_data["repository"]["refs"]["nodes"]]
     
-    # Track unique commit IDs
-    unique_commits = set()
+    repo_key = repository_key(repo_details)
+    repo_commit_count = 0
     
     for branch_name in branches:
         try:
@@ -107,29 +142,33 @@ async def update_data_with_commit_stats(repo_details: Dict, yearly_data: Dict, d
                 "repo_commit_list",
                 owner=repo_details["owner"]["login"],
                 name=repo_details["name"],
-                branch=branch_name
+                branch=branch_name,
+                authorId=author_id,
             )
             
             # Get the commit history nodes
             user_commits = [
                 commit for commit in commits["repository"]["ref"]["target"]["history"]["nodes"]
-                if commit["author"]["user"] and commit["author"]["user"]["login"] == target_username
-                and commit["oid"] not in unique_commits  # Only process new commits
+                if commit.get("author")
+                and commit["author"].get("user")
+                and commit["author"]["user"]["login"].lower() == target_username.lower()
+                and commit["oid"] not in seen_commit_oids
             ]
             
-            # Add commit IDs to the set
+            # Deduplicate Git objects across branches and repositories/forks.
             for commit in user_commits:
-                unique_commits.add(commit["oid"])
+                seen_commit_oids.add(commit["oid"])
+                repo_commit_count += 1
                 
                 date = search(r"\d+-\d+-\d+", commit["committedDate"]).group()
                 curr_year = datetime.fromisoformat(date).year
                 quarter = (datetime.fromisoformat(date).month - 1) // 3 + 1
 
-                if repo_details["name"] not in date_data:
-                    date_data[repo_details["name"]] = dict()
-                if branch_name not in date_data[repo_details["name"]]:
-                    date_data[repo_details["name"]][branch_name] = dict()
-                date_data[repo_details["name"]][branch_name][commit["oid"]] = commit["committedDate"]
+                if repo_key not in date_data:
+                    date_data[repo_key] = dict()
+                if branch_name not in date_data[repo_key]:
+                    date_data[repo_key][branch_name] = dict()
+                date_data[repo_key][branch_name][commit["oid"]] = commit["committedDate"]
 
                 if repo_details["primaryLanguage"] is not None:
                     if curr_year not in yearly_data:
@@ -143,9 +182,10 @@ async def update_data_with_commit_stats(repo_details: Dict, yearly_data: Dict, d
                     
         except Exception as e:
             DBM.w(f"\t\tError processing branch {branch_name}: {str(e)}")
+            raise
     
     # Print repository info with unique commit count
-    DBM.i(f"\t\t{repo_details['owner']['login']}/{repo_details['name']}: {len(unique_commits)} commits")
+    DBM.i(f"\t\t{repo_key}: {repo_commit_count} commits")
 
     if not EM.DEBUG_RUN:
         await sleep(0.4)

--- a/tests/test_commit_collection.py
+++ b/tests/test_commit_collection.py
@@ -1,0 +1,293 @@
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from sources.graphics_list_formatter import make_commit_day_time_list
+from sources.manager_download import DownloadManager, GITHUB_API_QUERIES
+from sources.manager_environment import EnvironmentManager
+from sources.manager_file import FileManager
+from sources.yearly_commit_calculator import update_data_with_commit_stats
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self.status_code = status_code
+        self.headers = {}
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+@pytest.mark.asyncio
+async def test_commit_history_paginates_and_preserves_response_shape():
+    first_page = {
+        "data": {
+            "repository": {
+                "ref": {
+                    "target": {
+                        "history": {
+                            "nodes": [{"oid": "one"}],
+                            "pageInfo": {
+                                "hasNextPage": True,
+                                "endCursor": "cursor-1",
+                            },
+                        }
+                    }
+                }
+            }
+        }
+    }
+    second_page = {
+        "data": {
+            "repository": {
+                "ref": {
+                    "target": {
+                        "history": {
+                            "nodes": [{"oid": "two"}],
+                            "pageInfo": {
+                                "hasNextPage": False,
+                                "endCursor": "cursor-2",
+                            },
+                        }
+                    }
+                }
+            }
+        }
+    }
+    client = AsyncMock()
+    client.post.side_effect = [
+        FakeResponse(first_page),
+        FakeResponse(second_page),
+    ]
+
+    with patch.object(DownloadManager, "_CLIENT", client):
+        result = await DownloadManager._fetch_graphql_query(
+            "repo_commit_list",
+            {
+                "owner": "owner",
+                "name": "repo",
+                "branch": "main",
+                "authorId": "user-id",
+            },
+        )
+
+    history = result["repository"]["ref"]["target"]["history"]
+    assert [node["oid"] for node in history["nodes"]] == ["one", "two"]
+    assert client.post.await_count == 2
+    assert (
+        client.post.await_args_list[1].kwargs["json"]["variables"]["after"]
+        == "cursor-1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_branch_list_paginates():
+    def page(nodes, has_next_page, end_cursor):
+        return {
+            "data": {
+                "repository": {
+                    "refs": {
+                        "nodes": nodes,
+                        "pageInfo": {
+                            "hasNextPage": has_next_page,
+                            "endCursor": end_cursor,
+                        },
+                    }
+                }
+            }
+        }
+
+    client = AsyncMock()
+    client.post.side_effect = [
+        FakeResponse(page([{"name": "main"}], True, "cursor-1")),
+        FakeResponse(page([{"name": "feature"}], False, "cursor-2")),
+    ]
+
+    with patch.object(DownloadManager, "_CLIENT", client):
+        result = await DownloadManager._fetch_graphql_query(
+            "repo_branch_list",
+            {"owner": "owner", "name": "repo"},
+        )
+
+    assert [node["name"] for node in result["repository"]["refs"]["nodes"]] == [
+        "main",
+        "feature",
+    ]
+    assert client.post.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_pagination_fails_closed_after_retry_exhaustion():
+    client = AsyncMock()
+    client.post.return_value = FakeResponse({}, status_code=502)
+
+    with patch.object(DownloadManager, "_CLIENT", client), patch(
+        "sources.manager_download.sleep", new=AsyncMock()
+    ):
+        with pytest.raises(Exception, match="GraphQL query failed"):
+            await DownloadManager._fetch_graphql_query(
+                "repo_commit_list",
+                {
+                    "owner": "owner",
+                    "name": "repo",
+                    "branch": "main",
+                    "authorId": "user-id",
+                },
+            )
+
+    assert client.post.await_count == 5
+
+
+@pytest.mark.asyncio
+async def test_branch_history_deduplicates_across_branches_and_forks():
+    repositories = [
+        {
+            "name": "same-name",
+            "nameWithOwner": "one/same-name",
+            "owner": {"login": "one"},
+            "primaryLanguage": {"name": "Python"},
+        },
+        {
+            "name": "same-name",
+            "nameWithOwner": "two/same-name",
+            "owner": {"login": "two"},
+            "primaryLanguage": {"name": "Python"},
+        },
+    ]
+    commits = {
+        ("one", "main"): [
+            {
+                "oid": "shared",
+                "committedDate": "2026-01-01T12:00:00Z",
+                "additions": 1,
+                "deletions": 0,
+                "author": {"user": {"login": "VatsalSy"}},
+            },
+            {
+                "oid": "one-only",
+                "committedDate": "2026-01-02T12:00:00Z",
+                "additions": 1,
+                "deletions": 0,
+                "author": {"user": {"login": "VatsalSy"}},
+            },
+        ],
+        ("one", "feature"): [
+            {
+                "oid": "shared",
+                "committedDate": "2026-01-01T12:00:00Z",
+                "additions": 1,
+                "deletions": 0,
+                "author": {"user": {"login": "VatsalSy"}},
+            }
+        ],
+        ("two", "main"): [
+            {
+                "oid": "shared",
+                "committedDate": "2026-01-01T12:00:00Z",
+                "additions": 1,
+                "deletions": 0,
+                "author": {"user": {"login": "VatsalSy"}},
+            },
+            {
+                "oid": "two-only",
+                "committedDate": "2026-01-03T12:00:00Z",
+                "additions": 1,
+                "deletions": 0,
+                "author": {"user": {"login": "VatsalSy"}},
+            },
+        ],
+    }
+
+    async def graphql(query, **kwargs):
+        if query == "repo_branch_list":
+            branch_names = ["main", "feature"] if kwargs["owner"] == "one" else ["main"]
+            return {
+                "repository": {
+                    "refs": {"nodes": [{"name": name} for name in branch_names]}
+                }
+            }
+        nodes = commits[(kwargs["owner"], kwargs["branch"])]
+        return {"repository": {"ref": {"target": {"history": {"nodes": nodes}}}}}
+
+    yearly_data = {}
+    date_data = {}
+    seen_commit_oids = set()
+
+    with patch.object(DownloadManager, "get_remote_graphql", side_effect=graphql):
+        for repository in repositories:
+            await update_data_with_commit_stats(
+                repository,
+                yearly_data,
+                date_data,
+                "VatsalSy",
+                "user-id",
+                seen_commit_oids,
+            )
+
+    assert seen_commit_oids == {"shared", "one-only", "two-only"}
+    assert set(date_data) == {"one/same-name", "two/same-name"}
+    assert (
+        sum(
+            len(branch)
+            for repository in date_data.values()
+            for branch in repository.values()
+        )
+        == 3
+    )
+
+    with patch.object(EnvironmentManager, "SHOW_TOTAL_COMMITS", True), patch.object(
+        EnvironmentManager, "SHOW_COMMIT", False
+    ), patch.object(EnvironmentManager, "SHOW_DAYS_OF_WEEK", False):
+        output = await make_commit_day_time_list("UTC", repositories, date_data)
+    assert "Accessible unique commits across repository branches: 3" in output
+
+
+@pytest.mark.asyncio
+async def test_repository_collection_propagates_branch_failure():
+    repository = {
+        "name": "repo",
+        "nameWithOwner": "owner/repo",
+        "owner": {"login": "owner"},
+        "primaryLanguage": {"name": "Python"},
+    }
+
+    async def graphql(query, **kwargs):
+        if query == "repo_branch_list":
+            return {"repository": {"refs": {"nodes": [{"name": "main"}]}}}
+        raise RuntimeError("branch failed")
+
+    with patch.object(DownloadManager, "get_remote_graphql", side_effect=graphql):
+        with pytest.raises(RuntimeError, match="branch failed"):
+            await update_data_with_commit_stats(
+                repository,
+                {},
+                {},
+                "VatsalSy",
+                "user-id",
+                set(),
+            )
+
+
+def test_commit_cache_expires(tmp_path, monkeypatch):
+    monkeypatch.setattr(FileManager, "ASSETS_DIR", str(tmp_path))
+    monkeypatch.setattr(FileManager, "_ENCRYPTION_KEY", None)
+    FileManager.cache_binary("commits.json", {"count": 1}, assets=True)
+    cache_path = Path(tmp_path, "commits.json")
+
+    with patch(
+        "sources.manager_file.time.time", return_value=cache_path.stat().st_mtime + 11
+    ):
+        assert (
+            FileManager.cache_binary(
+                "commits.json",
+                assets=True,
+                max_age_seconds=10,
+            )
+            is None
+        )
+
+
+def test_commit_query_filters_by_github_user_identity():
+    assert "author: {id: $authorId}" in GITHUB_API_QUERIES["repo_commit_list"]


### PR DESCRIPTION
## Summary
- Replace the 100-commit branch sample with complete author-filtered pagination
- Make the custom count distinct from GitHub contribution-event totals

## Changes
- Paginate repositories, branches, and commit histories
- Deduplicate Git objects across branches and forks
- Key repositories by owner/name and fail closed on partial API results
- Expire local caches after 24 hours without publishing private-history cache data
- Label the output as accessible unique commits across repository branches

## Testing
- 47 pytest tests passed
- Python compile check passed
- Diff whitespace validation passed