### PR TITLE
Bound commit crawl and respect GitHub limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@
 - Perfect for understanding your coding schedule
 
 🔄 **Smart Commit Tracking**
-- Prevents double-counting of commits across branches
-- Uses commit hash tracking for accurate statistics
-- Handles merge commits and branch synchronization intelligently
-- Paginates complete author-filtered branch histories
+- Counts authored commits reachable from each accessible default branch
+- Deduplicates commit object IDs across repositories and forks
+- Uses GitHub account identity rather than author-name matching
+- Paginates with fail-closed page, request, cursor, and time budgets
 
 📊 **Analytics Include**
 - Time of day commit patterns (Early Bird vs Night Owl)
@@ -114,7 +114,7 @@ bash runTestLocallyDocker.sh
 name: GitHub Stats Update
 on:
   schedule:
-    - cron: '0 */4 * * *'  # Runs every 4 hours
+    - cron: '0 3 * * *'  # Runs daily at 03:00 UTC
   workflow_dispatch:      # Allows manual trigger
 
 jobs:

--- a/sources/graphics_list_formatter.py
+++ b/sources/graphics_list_formatter.py
@@ -109,7 +109,10 @@ async def make_commit_day_time_list(time_zone: str, repositories: Dict, commit_d
 
     # Add total commits count if enabled
     if EM.SHOW_TOTAL_COMMITS:
-        stats += f"**Accessible unique commits across repository branches: {total_commits}** \n\n"
+        stats += (
+            "**Accessible unique authored commits on repository default branches "
+            f"(last successful crawl): {total_commits}** \n\n"
+        )
 
     if EM.SHOW_COMMIT:
         dt_names = [f"{DAY_TIME_EMOJI[i]} {FM.t(DAY_TIME_NAMES[i])}" for i in range(len(day_times))]

--- a/sources/manager_download.py
+++ b/sources/manager_download.py
@@ -40,6 +40,9 @@ query($username: String!, $after: String) {
                     login
                 }
                 isPrivate
+                defaultBranchRef {
+                    name
+                }
             }
             pageInfo {
                 hasNextPage
@@ -99,7 +102,13 @@ class DownloadManager:
     _CLIENT: AsyncClient = None
     _REMOTE_RESOURCES_CACHE = {}
     _REMOTE_RESOURCES: List[Task] = []
+    _COLLECTION_STARTED_AT = 0.0
+    _GRAPHQL_ATTEMPTS = 0
     _LAST_GRAPHQL_REQUEST_AT = 0.0
+    _MAX_COLLECTION_SECONDS = 45 * 60
+    _MAX_GRAPHQL_ATTEMPTS = 1500
+    _MAX_HISTORY_PAGES = 100
+    _MAX_REPOSITORY_PAGES = 5
     _MIN_GRAPHQL_REQUEST_INTERVAL_SECONDS = 1.25
     target_username: str = None
 
@@ -107,6 +116,10 @@ class DownloadManager:
     async def init(cls, username: str):
         """Initialize download manager with headers"""
         cls.target_username = username
+        cls._COLLECTION_STARTED_AT = monotonic()
+        cls._GRAPHQL_ATTEMPTS = 0
+        cls._LAST_GRAPHQL_REQUEST_AT = 0.0
+        cls._REMOTE_RESOURCES_CACHE = {}
         cls.headers = {
             "Authorization": f"Bearer {EM.GH_COMMIT_TOKEN}",
             "Content-Type": "application/json",
@@ -193,9 +206,21 @@ class DownloadManager:
         max_retries = 5
         result = None
         base_variables = variables.copy()
+        page_count = 0
+        seen_cursors = set()
         
         while has_next_page and retry_count < max_retries:
             try:
+                max_pages = (
+                    DownloadManager._MAX_REPOSITORY_PAGES
+                    if query == "user_repository_list"
+                    else DownloadManager._MAX_HISTORY_PAGES
+                )
+                if query != "user_identity" and page_count >= max_pages:
+                    raise Exception(
+                        f"Page budget exceeded for GraphQL query: {query}"
+                    )
+
                 request_variables = base_variables.copy()
                 if end_cursor:
                     request_variables["after"] = end_cursor
@@ -208,6 +233,8 @@ class DownloadManager:
                         DownloadManager._MIN_GRAPHQL_REQUEST_INTERVAL_SECONDS - elapsed
                     )
                 DownloadManager._LAST_GRAPHQL_REQUEST_AT = monotonic()
+                DownloadManager._enforce_collection_budget()
+                DownloadManager._GRAPHQL_ATTEMPTS += 1
 
                 # Add timeout to prevent hanging
                 response = await DownloadManager._CLIENT.post(
@@ -310,8 +337,20 @@ class DownloadManager:
                 if result is None:
                     result = deepcopy(page_data)
                 all_nodes.extend(connection["nodes"])
+                page_count += 1
                 has_next_page = connection["pageInfo"]["hasNextPage"]
-                end_cursor = connection["pageInfo"]["endCursor"]
+                next_cursor = connection["pageInfo"]["endCursor"]
+                if has_next_page:
+                    if (
+                        not next_cursor
+                        or next_cursor == end_cursor
+                        or next_cursor in seen_cursors
+                    ):
+                        raise Exception(
+                            f"Invalid pagination cursor for GraphQL query: {query}"
+                        )
+                    seen_cursors.add(next_cursor)
+                end_cursor = next_cursor
                     
             except Exception as e:
                 error_msg = TokenManager.mask_token(str(e))
@@ -364,6 +403,21 @@ class DownloadManager:
                 pass
 
         return min(60 * (2 ** (retry_count - 1)), 15 * 60)
+
+    @staticmethod
+    def _enforce_collection_budget():
+        """Abort before an exhaustive crawl can overrun its global limits."""
+        if (
+            DownloadManager._GRAPHQL_ATTEMPTS
+            >= DownloadManager._MAX_GRAPHQL_ATTEMPTS
+        ):
+            raise Exception("GraphQL request budget exceeded")
+
+        if DownloadManager._COLLECTION_STARTED_AT == 0.0:
+            DownloadManager._COLLECTION_STARTED_AT = monotonic()
+        elapsed = monotonic() - DownloadManager._COLLECTION_STARTED_AT
+        if elapsed >= DownloadManager._MAX_COLLECTION_SECONDS:
+            raise Exception("GraphQL collection time budget exceeded")
 
     @staticmethod
     async def close_remote_resources():

--- a/sources/manager_download.py
+++ b/sources/manager_download.py
@@ -1,6 +1,7 @@
 from asyncio import Task
 from hashlib import sha256
 from json import dumps
+from time import monotonic, time
 from typing import Dict, List
 from asyncio import sleep
 from copy import deepcopy
@@ -98,6 +99,8 @@ class DownloadManager:
     _CLIENT: AsyncClient = None
     _REMOTE_RESOURCES_CACHE = {}
     _REMOTE_RESOURCES: List[Task] = []
+    _LAST_GRAPHQL_REQUEST_AT = 0.0
+    _MIN_GRAPHQL_REQUEST_INTERVAL_SECONDS = 1.25
     target_username: str = None
 
     @classmethod
@@ -198,7 +201,14 @@ class DownloadManager:
                     request_variables["after"] = end_cursor
 
                 DBM.i(f"Sending GraphQL query: {query} {'with cursor' if end_cursor else ''}")
-                
+
+                elapsed = monotonic() - DownloadManager._LAST_GRAPHQL_REQUEST_AT
+                if elapsed < DownloadManager._MIN_GRAPHQL_REQUEST_INTERVAL_SECONDS:
+                    await sleep(
+                        DownloadManager._MIN_GRAPHQL_REQUEST_INTERVAL_SECONDS - elapsed
+                    )
+                DownloadManager._LAST_GRAPHQL_REQUEST_AT = monotonic()
+
                 # Add timeout to prevent hanging
                 response = await DownloadManager._CLIENT.post(
                     "https://api.github.com/graphql",
@@ -209,12 +219,40 @@ class DownloadManager:
                     timeout=30.0  # 30 second timeout
                 )
                 
-                # Handle rate limiting
-                if response.status_code == 429:
-                    retry_after = int(response.headers.get('Retry-After', 60))
-                    DBM.w(f"Rate limit exceeded, waiting {retry_after} seconds")
-                    await sleep(retry_after)
+                try:
+                    response_data = response.json()
+                except Exception:
+                    response_data = {}
+                response_error_text = str(response_data.get("message", ""))
+                response_error_text += " " + str(response_data.get("errors", ""))
+
+                # GitHub returns secondary limits as HTTP 403, HTTP 429, or a
+                # GraphQL error inside an otherwise successful HTTP 200.
+                is_rate_limited = (
+                    response.status_code == 429
+                    or (
+                        response.status_code == 403
+                        and DownloadManager._is_rate_limit_error(response_error_text)
+                    )
+                    or (
+                        response.status_code == 200
+                        and "errors" in response_data
+                        and DownloadManager._is_rate_limit_error(response_error_text)
+                    )
+                )
+                if is_rate_limited:
                     retry_count += 1
+                    retry_after = DownloadManager._rate_limit_retry_after(
+                        response,
+                        retry_count,
+                    )
+                    DBM.w(
+                        "GitHub API rate limit reached; "
+                        f"retry {retry_count}/{max_retries} in {retry_after}s"
+                    )
+                    if retry_count >= max_retries:
+                        break
+                    await sleep(retry_after)
                     continue
 
                 # Handle transient server errors with exponential backoff
@@ -248,7 +286,7 @@ class DownloadManager:
                         
                     raise Exception(error_msg)
                     
-                data = response.json()
+                data = response_data
                 if "errors" in data:
                     error_text = TokenManager.mask_token(str(data['errors']))
                     raise Exception(f"GraphQL errors: {error_text}")
@@ -294,6 +332,38 @@ class DownloadManager:
         elif query == "repo_commit_list":
             result["repository"]["ref"]["target"]["history"]["nodes"] = all_nodes
         return result
+
+    @staticmethod
+    def _is_rate_limit_error(message: str) -> bool:
+        """Return whether a GitHub error describes primary or secondary limiting."""
+        normalized = message.lower()
+        return any(
+            marker in normalized
+            for marker in (
+                "rate limit",
+                "abuse detection",
+                "temporarily blocked",
+            )
+        )
+
+    @staticmethod
+    def _rate_limit_retry_after(response, retry_count: int) -> int:
+        """Choose a conservative wait using GitHub headers when available."""
+        retry_after = response.headers.get("Retry-After")
+        if retry_after:
+            try:
+                return max(1, int(retry_after))
+            except (TypeError, ValueError):
+                pass
+
+        if response.headers.get("x-ratelimit-remaining") == "0":
+            try:
+                reset_at = int(response.headers["x-ratelimit-reset"])
+                return max(1, reset_at - int(time()) + 5)
+            except (KeyError, TypeError, ValueError):
+                pass
+
+        return min(60 * (2 ** (retry_count - 1)), 15 * 60)
 
     @staticmethod
     async def close_remote_resources():

--- a/sources/yearly_commit_calculator.py
+++ b/sources/yearly_commit_calculator.py
@@ -1,7 +1,6 @@
 from asyncio import sleep
-from json import dumps
 from re import search
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Dict, Tuple, List, Set
 import os
 from hashlib import sha256
@@ -10,10 +9,9 @@ from .manager_download import DownloadManager as DM
 from .manager_environment import EnvironmentManager as EM
 from .manager_file import FileManager as FM
 from .manager_debug import DebugManager as DBM
-from .manager_token import TokenManager
 
-COMMIT_CACHE_MAX_AGE_SECONDS = 24 * 60 * 60
-CACHE_SCHEMA_VERSION = 2
+COMMIT_CACHE_MAX_AGE_SECONDS = 36 * 60 * 60
+CACHE_SCHEMA_VERSION = 3
 
 
 def ensure_cache_dir():
@@ -32,8 +30,10 @@ async def calculate_commit_data(repositories: List[Dict], target_username: str) 
     :param target_username: GitHub username of the authenticated user.
     :returns: Commit quarter yearly data dictionary.
     """
-    ensure_cache_dir()
     DBM.i("Calculating commit data...")
+    cache_enabled = os.getenv("GITHUB_ACTIONS", "").lower() != "true"
+    if cache_enabled:
+        ensure_cache_dir()
     
     # Create cache filename with username (using hash for safety)
     cache_filename = (
@@ -41,28 +41,32 @@ async def calculate_commit_data(repositories: List[Dict], target_username: str) 
         f"{sha256(target_username.encode()).hexdigest()}.json"
     )
     
-    # Try to load cached data if it's recent enough
-    try:
-        cached_data = FM.cache_binary(
-            cache_filename,
-            assets=True,
-            max_age_seconds=COMMIT_CACHE_MAX_AGE_SECONDS,
-        )
-        if cached_data is not None:
-            yearly_data, date_data = cached_data
-            
-            # Validate cache structure without using string operations
-            if (isinstance(yearly_data, dict) and 
-                isinstance(date_data, dict) and
-                all(isinstance(v, dict) for v in yearly_data.values()) and
-                all(isinstance(v, dict) for v in date_data.values())):
+    # GitHub-hosted runners are ephemeral. Avoid producing a cache that cannot
+    # be reused, and never upload private-history metadata to a public cache.
+    if cache_enabled:
+        try:
+            cached_data = FM.cache_binary(
+                cache_filename,
+                assets=True,
+                max_age_seconds=COMMIT_CACHE_MAX_AGE_SECONDS,
+            )
+            if cached_data is not None:
+                yearly_data, date_data = cached_data
                 
-                DBM.i("Commit data restored from cache!")
-                return yearly_data, date_data
-            else:
-                DBM.w("Cache data validation failed - fetching fresh data")
-    except Exception as e:
-        DBM.w(f"Cache load failed: {str(e)} - fetching fresh data")
+                # Validate cache structure without using string operations
+                if (isinstance(yearly_data, dict) and
+                    isinstance(date_data, dict) and
+                    all(isinstance(v, dict) for v in yearly_data.values()) and
+                    all(isinstance(v, dict) for v in date_data.values())):
+
+                    DBM.i("Commit data restored from cache!")
+                    return yearly_data, date_data
+                else:
+                    DBM.w("Cache data validation failed - fetching fresh data")
+        except Exception as e:
+            DBM.w(f"Cache load failed: {str(e)} - fetching fresh data")
+    else:
+        DBM.i("Skipping commit cache on the GitHub-hosted runner.")
 
     DBM.i("Fetching fresh commit data...")
     yearly_data = dict()
@@ -86,9 +90,10 @@ async def calculate_commit_data(repositories: List[Dict], target_username: str) 
     
     DBM.i("Commit data calculated!")
     
-    # Cache the data for this specific username
-    FM.cache_binary(cache_filename, [yearly_data, date_data], assets=True)
-    DBM.i("New commit data saved to cache!")
+    if cache_enabled:
+        # Cache the data for this specific username during local development.
+        FM.cache_binary(cache_filename, [yearly_data, date_data], assets=True)
+        DBM.i("New commit data saved to cache!")
     
     return yearly_data, date_data
 
@@ -118,71 +123,61 @@ async def update_data_with_commit_stats(
     :param date_data: Commit date dictionary to update.
     :param target_username: GitHub username of the authenticated user.
     """
-    try:
-        branches_data = await DM.get_remote_graphql(
-            "repo_branch_list",
-            owner=repo_details["owner"]["login"],
-            name=repo_details["name"]
-        )
-    except Exception as e:
-        # Use TokenManager to mask any sensitive info in error message
-        error_msg = TokenManager.mask_token(str(e))
-        DBM.w(f"\t\tError fetching branches: {error_msg}")
-        raise
-    
-    # Extract branch names from the response structure
-    branches = [branch["name"] for branch in branches_data["repository"]["refs"]["nodes"]]
-    
     repo_key = repository_key(repo_details)
+    default_branch = repo_details.get("defaultBranchRef")
+    branch_name = default_branch.get("name") if default_branch else None
+    if not branch_name:
+        DBM.i(f"\t\t{repo_key}: skipped empty repository")
+        return
+
     repo_commit_count = 0
-    
-    for branch_name in branches:
-        try:
-            commits = await DM.get_remote_graphql(
-                "repo_commit_list",
-                owner=repo_details["owner"]["login"],
-                name=repo_details["name"],
-                branch=branch_name,
-                authorId=author_id,
-            )
+
+    try:
+        commits = await DM.get_remote_graphql(
+            "repo_commit_list",
+            owner=repo_details["owner"]["login"],
+            name=repo_details["name"],
+            branch=branch_name,
+            authorId=author_id,
+        )
+
+        # Get the commit history nodes
+        user_commits = [
+            commit for commit in commits["repository"]["ref"]["target"]["history"]["nodes"]
+            if commit.get("author")
+            and commit["author"].get("user")
+            and commit["author"]["user"]["login"].lower() == target_username.lower()
+            and commit["oid"] not in seen_commit_oids
+        ]
+
+        # Deduplicate Git objects across repositories and forks.
+        for commit in user_commits:
+            seen_commit_oids.add(commit["oid"])
+            repo_commit_count += 1
             
-            # Get the commit history nodes
-            user_commits = [
-                commit for commit in commits["repository"]["ref"]["target"]["history"]["nodes"]
-                if commit.get("author")
-                and commit["author"].get("user")
-                and commit["author"]["user"]["login"].lower() == target_username.lower()
-                and commit["oid"] not in seen_commit_oids
-            ]
-            
-            # Deduplicate Git objects across branches and repositories/forks.
-            for commit in user_commits:
-                seen_commit_oids.add(commit["oid"])
-                repo_commit_count += 1
+            date = search(r"\d+-\d+-\d+", commit["committedDate"]).group()
+            curr_year = datetime.fromisoformat(date).year
+            quarter = (datetime.fromisoformat(date).month - 1) // 3 + 1
+
+            if repo_key not in date_data:
+                date_data[repo_key] = dict()
+            if branch_name not in date_data[repo_key]:
+                date_data[repo_key][branch_name] = dict()
+            date_data[repo_key][branch_name][commit["oid"]] = commit["committedDate"]
+
+            if repo_details["primaryLanguage"] is not None:
+                if curr_year not in yearly_data:
+                    yearly_data[curr_year] = dict()
+                if quarter not in yearly_data[curr_year]:
+                    yearly_data[curr_year][quarter] = dict()
+                if repo_details["primaryLanguage"]["name"] not in yearly_data[curr_year][quarter]:
+                    yearly_data[curr_year][quarter][repo_details["primaryLanguage"]["name"]] = {"add": 0, "del": 0}
+                yearly_data[curr_year][quarter][repo_details["primaryLanguage"]["name"]]["add"] += commit["additions"]
+                yearly_data[curr_year][quarter][repo_details["primaryLanguage"]["name"]]["del"] += commit["deletions"]
                 
-                date = search(r"\d+-\d+-\d+", commit["committedDate"]).group()
-                curr_year = datetime.fromisoformat(date).year
-                quarter = (datetime.fromisoformat(date).month - 1) // 3 + 1
-
-                if repo_key not in date_data:
-                    date_data[repo_key] = dict()
-                if branch_name not in date_data[repo_key]:
-                    date_data[repo_key][branch_name] = dict()
-                date_data[repo_key][branch_name][commit["oid"]] = commit["committedDate"]
-
-                if repo_details["primaryLanguage"] is not None:
-                    if curr_year not in yearly_data:
-                        yearly_data[curr_year] = dict()
-                    if quarter not in yearly_data[curr_year]:
-                        yearly_data[curr_year][quarter] = dict()
-                    if repo_details["primaryLanguage"]["name"] not in yearly_data[curr_year][quarter]:
-                        yearly_data[curr_year][quarter][repo_details["primaryLanguage"]["name"]] = {"add": 0, "del": 0}
-                    yearly_data[curr_year][quarter][repo_details["primaryLanguage"]["name"]]["add"] += commit["additions"]
-                    yearly_data[curr_year][quarter][repo_details["primaryLanguage"]["name"]]["del"] += commit["deletions"]
-                    
-        except Exception as e:
-            DBM.w(f"\t\tError processing branch {branch_name}: {str(e)}")
-            raise
+    except Exception as e:
+        DBM.w(f"\t\tError processing default branch {branch_name}: {str(e)}")
+        raise
     
     # Print repository info with unique commit count
     DBM.i(f"\t\t{repo_key}: {repo_commit_count} commits")

--- a/tests/test_commit_collection.py
+++ b/tests/test_commit_collection.py
@@ -141,6 +141,59 @@ async def test_pagination_fails_closed_after_retry_exhaustion():
 
 
 @pytest.mark.asyncio
+async def test_secondary_rate_limit_retries_the_current_page():
+    limited = {
+        "errors": [
+            {
+                "type": "RATE_LIMITED",
+                "message": "You have exceeded a secondary rate limit.",
+            }
+        ]
+    }
+    success = {
+        "data": {
+            "repository": {
+                "ref": {
+                    "target": {
+                        "history": {
+                            "nodes": [{"oid": "one"}],
+                            "pageInfo": {
+                                "hasNextPage": False,
+                                "endCursor": "cursor-1",
+                            },
+                        }
+                    }
+                }
+            }
+        }
+    }
+    client = AsyncMock()
+    client.post.side_effect = [
+        FakeResponse(limited),
+        FakeResponse(success),
+    ]
+    sleeper = AsyncMock()
+
+    with patch.object(DownloadManager, "_CLIENT", client), patch.object(
+        DownloadManager, "_MIN_GRAPHQL_REQUEST_INTERVAL_SECONDS", 0
+    ), patch("sources.manager_download.sleep", new=sleeper):
+        result = await DownloadManager._fetch_graphql_query(
+            "repo_commit_list",
+            {
+                "owner": "owner",
+                "name": "repo",
+                "branch": "main",
+                "authorId": "user-id",
+            },
+        )
+
+    history = result["repository"]["ref"]["target"]["history"]
+    assert [node["oid"] for node in history["nodes"]] == ["one"]
+    assert client.post.await_count == 2
+    sleeper.assert_awaited_once_with(60)
+
+
+@pytest.mark.asyncio
 async def test_branch_history_deduplicates_across_branches_and_forks():
     repositories = [
         {

--- a/tests/test_commit_collection.py
+++ b/tests/test_commit_collection.py
@@ -7,7 +7,10 @@ from sources.graphics_list_formatter import make_commit_day_time_list
 from sources.manager_download import DownloadManager, GITHUB_API_QUERIES
 from sources.manager_environment import EnvironmentManager
 from sources.manager_file import FileManager
-from sources.yearly_commit_calculator import update_data_with_commit_stats
+from sources.yearly_commit_calculator import (
+    calculate_commit_data,
+    update_data_with_commit_stats,
+)
 
 
 class FakeResponse:
@@ -194,19 +197,21 @@ async def test_secondary_rate_limit_retries_the_current_page():
 
 
 @pytest.mark.asyncio
-async def test_branch_history_deduplicates_across_branches_and_forks():
+async def test_default_branch_history_deduplicates_across_forks():
     repositories = [
         {
             "name": "same-name",
             "nameWithOwner": "one/same-name",
             "owner": {"login": "one"},
             "primaryLanguage": {"name": "Python"},
+            "defaultBranchRef": {"name": "main"},
         },
         {
             "name": "same-name",
             "nameWithOwner": "two/same-name",
             "owner": {"login": "two"},
             "primaryLanguage": {"name": "Python"},
+            "defaultBranchRef": {"name": "main"},
         },
     ]
     commits = {
@@ -225,15 +230,6 @@ async def test_branch_history_deduplicates_across_branches_and_forks():
                 "deletions": 0,
                 "author": {"user": {"login": "VatsalSy"}},
             },
-        ],
-        ("one", "feature"): [
-            {
-                "oid": "shared",
-                "committedDate": "2026-01-01T12:00:00Z",
-                "additions": 1,
-                "deletions": 0,
-                "author": {"user": {"login": "VatsalSy"}},
-            }
         ],
         ("two", "main"): [
             {
@@ -254,13 +250,6 @@ async def test_branch_history_deduplicates_across_branches_and_forks():
     }
 
     async def graphql(query, **kwargs):
-        if query == "repo_branch_list":
-            branch_names = ["main", "feature"] if kwargs["owner"] == "one" else ["main"]
-            return {
-                "repository": {
-                    "refs": {"nodes": [{"name": name} for name in branch_names]}
-                }
-            }
         nodes = commits[(kwargs["owner"], kwargs["branch"])]
         return {"repository": {"ref": {"target": {"history": {"nodes": nodes}}}}}
 
@@ -294,21 +283,23 @@ async def test_branch_history_deduplicates_across_branches_and_forks():
         EnvironmentManager, "SHOW_COMMIT", False
     ), patch.object(EnvironmentManager, "SHOW_DAYS_OF_WEEK", False):
         output = await make_commit_day_time_list("UTC", repositories, date_data)
-    assert "Accessible unique commits across repository branches: 3" in output
+    assert (
+        "Accessible unique authored commits on repository default branches "
+        "(last successful crawl): 3"
+    ) in output
 
 
 @pytest.mark.asyncio
-async def test_repository_collection_propagates_branch_failure():
+async def test_repository_collection_propagates_default_branch_failure():
     repository = {
         "name": "repo",
         "nameWithOwner": "owner/repo",
         "owner": {"login": "owner"},
         "primaryLanguage": {"name": "Python"},
+        "defaultBranchRef": {"name": "main"},
     }
 
     async def graphql(query, **kwargs):
-        if query == "repo_branch_list":
-            return {"repository": {"refs": {"nodes": [{"name": "main"}]}}}
         raise RuntimeError("branch failed")
 
     with patch.object(DownloadManager, "get_remote_graphql", side_effect=graphql):
@@ -321,6 +312,126 @@ async def test_repository_collection_propagates_branch_failure():
                 "user-id",
                 set(),
             )
+
+
+@pytest.mark.asyncio
+async def test_empty_repository_skips_history_query():
+    repository = {
+        "name": "empty",
+        "nameWithOwner": "owner/empty",
+        "owner": {"login": "owner"},
+        "primaryLanguage": None,
+        "defaultBranchRef": None,
+    }
+
+    with patch.object(
+        DownloadManager,
+        "get_remote_graphql",
+        new=AsyncMock(),
+    ) as graphql:
+        await update_data_with_commit_stats(
+            repository,
+            {},
+            {},
+            "VatsalSy",
+            "user-id",
+            set(),
+        )
+
+    graphql.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_github_actions_runner_does_not_read_or_write_commit_cache():
+    identity = {"user": {"id": "user-id"}}
+
+    with patch.dict("os.environ", {"GITHUB_ACTIONS": "true"}), patch.object(
+        FileManager,
+        "cache_binary",
+    ) as cache_binary, patch.object(
+        DownloadManager,
+        "get_remote_graphql",
+        new=AsyncMock(return_value=identity),
+    ):
+        await calculate_commit_data([], "VatsalSy")
+
+    cache_binary.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pagination_rejects_missing_next_cursor():
+    page = {
+        "data": {
+            "repository": {
+                "ref": {
+                    "target": {
+                        "history": {
+                            "nodes": [{"oid": "one"}],
+                            "pageInfo": {
+                                "hasNextPage": True,
+                                "endCursor": None,
+                            },
+                        }
+                    }
+                }
+            }
+        }
+    }
+    client = AsyncMock()
+    client.post.return_value = FakeResponse(page)
+
+    with patch.object(DownloadManager, "_CLIENT", client), patch.object(
+        DownloadManager, "_MIN_GRAPHQL_REQUEST_INTERVAL_SECONDS", 0
+    ):
+        with pytest.raises(Exception, match="Invalid pagination cursor"):
+            await DownloadManager._fetch_graphql_query(
+                "repo_commit_list",
+                {
+                    "owner": "owner",
+                    "name": "repo",
+                    "branch": "main",
+                    "authorId": "user-id",
+                },
+            )
+
+
+@pytest.mark.asyncio
+async def test_history_page_budget_fails_closed():
+    page = {
+        "data": {
+            "repository": {
+                "ref": {
+                    "target": {
+                        "history": {
+                            "nodes": [{"oid": "one"}],
+                            "pageInfo": {
+                                "hasNextPage": True,
+                                "endCursor": "cursor-1",
+                            },
+                        }
+                    }
+                }
+            }
+        }
+    }
+    client = AsyncMock()
+    client.post.return_value = FakeResponse(page)
+
+    with patch.object(DownloadManager, "_CLIENT", client), patch.object(
+        DownloadManager, "_MIN_GRAPHQL_REQUEST_INTERVAL_SECONDS", 0
+    ), patch.object(DownloadManager, "_MAX_HISTORY_PAGES", 1):
+        with pytest.raises(Exception, match="Page budget exceeded"):
+            await DownloadManager._fetch_graphql_query(
+                "repo_commit_list",
+                {
+                    "owner": "owner",
+                    "name": "repo",
+                    "branch": "main",
+                    "authorId": "user-id",
+                },
+            )
+
+    assert client.post.await_count == 1
 
 
 def test_commit_cache_expires(tmp_path, monkeypatch):
@@ -344,3 +455,11 @@ def test_commit_cache_expires(tmp_path, monkeypatch):
 
 def test_commit_query_filters_by_github_user_identity():
     assert "author: {id: $authorId}" in GITHUB_API_QUERIES["repo_commit_list"]
+    assert "defaultBranchRef" in GITHUB_API_QUERIES["user_repository_list"]
+
+
+def test_collection_safety_budgets_are_bounded():
+    assert DownloadManager._MAX_REPOSITORY_PAGES == 5
+    assert DownloadManager._MAX_HISTORY_PAGES == 100
+    assert DownloadManager._MAX_GRAPHQL_ATTEMPTS == 1500
+    assert DownloadManager._MAX_COLLECTION_SECONDS == 45 * 60


### PR DESCRIPTION
## Summary
- count globally unique authored commits reachable from accessible repository default branches
- pace GraphQL requests and retry HTTP or in-band secondary-limit responses without losing pagination progress
- fail closed on 500-repository, 100-history-page, 1,500-request, 45-minute, or invalid-cursor limits
- skip persistent caching on GitHub-hosted runners so private-history metadata never enters a public Actions cache
- document the daily schedule and exact metric semantics

## Evidence
- the exhaustive all-branch run hit GitHub secondary limiting after 24 of 357 repositories
- 53 tests pass, including rate-limit, cursor, page-budget, default-branch, deduplication, empty-repository, and Actions-cache regressions
- compile and diff checks pass