### PR TITLE
Partition pathological commit histories

### DIFF
--- a/sources/manager_download.py
+++ b/sources/manager_download.py
@@ -18,6 +18,7 @@ query($username: String!) {
     user(login: $username) {
         id
         login
+        createdAt
     }
 }
 """,
@@ -74,6 +75,49 @@ query($owner: String!, $name: String!, $branch: String!, $authorId: ID!, $after:
             target {
                 ... on Commit {
                     history(first: 100, after: $after, author: {id: $authorId}) {
+                        nodes {
+                            committedDate
+                            oid
+                            additions
+                            deletions
+                            author {
+                                user {
+                                    login
+                                }
+                            }
+                        }
+                        pageInfo {
+                            hasNextPage
+                            endCursor
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+""",
+    "repo_commit_list_window": """
+query(
+    $owner: String!,
+    $name: String!,
+    $branch: String!,
+    $authorId: ID!,
+    $since: GitTimestamp!,
+    $until: GitTimestamp!,
+    $after: String
+) {
+    repository(owner: $owner, name: $name) {
+        ref(qualifiedName: $branch) {
+            target {
+                ... on Commit {
+                    history(
+                        first: 100,
+                        after: $after,
+                        author: {id: $authorId},
+                        since: $since,
+                        until: $until
+                    ) {
                         nodes {
                             committedDate
                             oid
@@ -157,7 +201,15 @@ class DownloadManager:
             'user_identity': ['username'],
             'user_repository_list': ['username'],
             'repo_branch_list': ['owner', 'name'],
-            'repo_commit_list': ['owner', 'name', 'branch', 'authorId']
+            'repo_commit_list': ['owner', 'name', 'branch', 'authorId'],
+            'repo_commit_list_window': [
+                'owner',
+                'name',
+                'branch',
+                'authorId',
+                'since',
+                'until',
+            ],
         }
         
         missing_vars = [var for var in required_vars[query] if var not in kwargs]
@@ -368,7 +420,7 @@ class DownloadManager:
             return all_nodes
         if query == "repo_branch_list":
             result["repository"]["refs"]["nodes"] = all_nodes
-        elif query == "repo_commit_list":
+        elif query in ("repo_commit_list", "repo_commit_list_window"):
             result["repository"]["ref"]["target"]["history"]["nodes"] = all_nodes
         return result
 

--- a/sources/yearly_commit_calculator.py
+++ b/sources/yearly_commit_calculator.py
@@ -75,6 +75,9 @@ async def calculate_commit_data(repositories: List[Dict], target_username: str) 
 
     identity = await DM.get_remote_graphql("user_identity", username=target_username)
     author_id = identity["user"]["id"]
+    account_created_year = datetime.fromisoformat(
+        identity["user"]["createdAt"].replace("Z", "+00:00")
+    ).year
     
     # Process repositories one by one
     for i, repo in enumerate(repositories, 1):
@@ -86,6 +89,7 @@ async def calculate_commit_data(repositories: List[Dict], target_username: str) 
             target_username,
             author_id,
             seen_commit_oids,
+            account_created_year,
         )
     
     DBM.i("Commit data calculated!")
@@ -106,6 +110,45 @@ def repository_key(repo_details: Dict) -> str:
     )
 
 
+async def get_default_branch_commits(
+    repo_details: Dict,
+    branch_name: str,
+    author_id: str,
+    account_created_year: int,
+) -> List[Dict]:
+    """Fetch one default-branch history, partitioning only persistent 5xx cases."""
+    query_args = {
+        "owner": repo_details["owner"]["login"],
+        "name": repo_details["name"],
+        "branch": branch_name,
+        "authorId": author_id,
+    }
+    try:
+        commits = await DM.get_remote_graphql("repo_commit_list", **query_args)
+        return commits["repository"]["ref"]["target"]["history"]["nodes"]
+    except Exception as error:
+        transient_markers = ("HTTP 502", "HTTP 503", "HTTP 504")
+        if not any(marker in str(error) for marker in transient_markers):
+            raise
+
+    DBM.w(
+        "\t\tFull history query failed after retries; "
+        "retrying in bounded yearly windows."
+    )
+    commit_nodes = []
+    for year in range(account_created_year, datetime.now().year + 1):
+        commits = await DM.get_remote_graphql(
+            "repo_commit_list_window",
+            **query_args,
+            since=f"{year}-01-01T00:00:00Z",
+            until=f"{year + 1}-01-01T00:00:00Z",
+        )
+        commit_nodes.extend(
+            commits["repository"]["ref"]["target"]["history"]["nodes"]
+        )
+    return commit_nodes
+
+
 async def update_data_with_commit_stats(
     repo_details: Dict,
     yearly_data: Dict,
@@ -113,6 +156,7 @@ async def update_data_with_commit_stats(
     target_username: str,
     author_id: str,
     seen_commit_oids: Set[str],
+    account_created_year: int,
 ):
     """
     Updates yearly commit data with commits from given repository.
@@ -133,17 +177,16 @@ async def update_data_with_commit_stats(
     repo_commit_count = 0
 
     try:
-        commits = await DM.get_remote_graphql(
-            "repo_commit_list",
-            owner=repo_details["owner"]["login"],
-            name=repo_details["name"],
-            branch=branch_name,
-            authorId=author_id,
+        commits = await get_default_branch_commits(
+            repo_details,
+            branch_name,
+            author_id,
+            account_created_year,
         )
 
         # Get the commit history nodes
         user_commits = [
-            commit for commit in commits["repository"]["ref"]["target"]["history"]["nodes"]
+            commit for commit in commits
             if commit.get("author")
             and commit["author"].get("user")
             and commit["author"]["user"]["login"].lower() == target_username.lower()

--- a/tests/test_commit_collection.py
+++ b/tests/test_commit_collection.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from datetime import datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -9,6 +10,7 @@ from sources.manager_environment import EnvironmentManager
 from sources.manager_file import FileManager
 from sources.yearly_commit_calculator import (
     calculate_commit_data,
+    get_default_branch_commits,
     update_data_with_commit_stats,
 )
 
@@ -266,6 +268,7 @@ async def test_default_branch_history_deduplicates_across_forks():
                 "VatsalSy",
                 "user-id",
                 seen_commit_oids,
+                2016,
             )
 
     assert seen_commit_oids == {"shared", "one-only", "two-only"}
@@ -311,6 +314,7 @@ async def test_repository_collection_propagates_default_branch_failure():
                 "VatsalSy",
                 "user-id",
                 set(),
+                2016,
             )
 
 
@@ -336,14 +340,65 @@ async def test_empty_repository_skips_history_query():
             "VatsalSy",
             "user-id",
             set(),
+            2016,
         )
 
     graphql.assert_not_awaited()
 
 
 @pytest.mark.asyncio
+async def test_large_history_5xx_falls_back_to_year_window():
+    repository = {
+        "name": "large",
+        "nameWithOwner": "owner/large",
+        "owner": {"login": "owner"},
+    }
+    windowed = {
+        "repository": {
+            "ref": {
+                "target": {
+                    "history": {
+                        "nodes": [{"oid": "one"}],
+                    }
+                }
+            }
+        }
+    }
+    graphql = AsyncMock(
+        side_effect=[
+            RuntimeError("GraphQL query failed: HTTP 502"),
+            windowed,
+        ]
+    )
+    current_year = datetime.now().year
+
+    with patch.object(DownloadManager, "get_remote_graphql", new=graphql):
+        commits = await get_default_branch_commits(
+            repository,
+            "main",
+            "user-id",
+            current_year,
+        )
+
+    assert commits == [{"oid": "one"}]
+    assert graphql.await_count == 2
+    assert graphql.await_args_list[1].args == ("repo_commit_list_window",)
+    assert graphql.await_args_list[1].kwargs["since"] == (
+        f"{current_year}-01-01T00:00:00Z"
+    )
+    assert graphql.await_args_list[1].kwargs["until"] == (
+        f"{current_year + 1}-01-01T00:00:00Z"
+    )
+
+
+@pytest.mark.asyncio
 async def test_github_actions_runner_does_not_read_or_write_commit_cache():
-    identity = {"user": {"id": "user-id"}}
+    identity = {
+        "user": {
+            "id": "user-id",
+            "createdAt": "2016-02-06T00:00:00Z",
+        }
+    }
 
     with patch.dict("os.environ", {"GITHUB_ACTIONS": "true"}), patch.object(
         FileManager,


### PR DESCRIPTION
## Summary
- retain the fast complete-history query for normal default branches
- after persistent GitHub 502/503/504 responses only, retry that repository in account-lifetime yearly windows
- preserve the existing page, request, cursor, retry, and wall-clock budgets

## Evidence
- live profile run 30217690128 reached repository 247/357, then comphy-lab/basilisk-C returned HTTP 502 on five complete-history attempts
- the equivalent 2025 yearly-window query succeeds and returns 49 authored commits
- 54 tests pass, including the 5xx fallback regression; compile and diff checks pass