### PR TITLE
Drop unused commit diff statistics

### DIFF
--- a/sources/manager_download.py
+++ b/sources/manager_download.py
@@ -32,9 +32,6 @@ query($username: String!, $after: String) {
             ownerAffiliations: [OWNER, ORGANIZATION_MEMBER, COLLABORATOR]
         ) {
             nodes {
-                primaryLanguage {
-                    name
-                }
                 name
                 nameWithOwner
                 owner {
@@ -78,8 +75,6 @@ query($owner: String!, $name: String!, $branch: String!, $authorId: ID!, $after:
                         nodes {
                             committedDate
                             oid
-                            additions
-                            deletions
                             author {
                                 user {
                                     login
@@ -121,8 +116,6 @@ query(
                         nodes {
                             committedDate
                             oid
-                            additions
-                            deletions
                             author {
                                 user {
                                     login

--- a/sources/yearly_commit_calculator.py
+++ b/sources/yearly_commit_calculator.py
@@ -1,5 +1,4 @@
 from asyncio import sleep
-from re import search
 from datetime import datetime
 from typing import Dict, Tuple, List, Set
 import os
@@ -23,8 +22,7 @@ def ensure_cache_dir():
 
 async def calculate_commit_data(repositories: List[Dict], target_username: str) -> Tuple[Dict, Dict]:
     """
-    Calculate commit data by years with secure caching.
-    Commit data includes contribution additions and deletions in each quarter of each recorded year.
+    Calculate authored commit timestamps with secure local caching.
 
     :param repositories: user repositories info dictionary.
     :param target_username: GitHub username of the authenticated user.
@@ -198,25 +196,11 @@ async def update_data_with_commit_stats(
             seen_commit_oids.add(commit["oid"])
             repo_commit_count += 1
             
-            date = search(r"\d+-\d+-\d+", commit["committedDate"]).group()
-            curr_year = datetime.fromisoformat(date).year
-            quarter = (datetime.fromisoformat(date).month - 1) // 3 + 1
-
             if repo_key not in date_data:
                 date_data[repo_key] = dict()
             if branch_name not in date_data[repo_key]:
                 date_data[repo_key][branch_name] = dict()
             date_data[repo_key][branch_name][commit["oid"]] = commit["committedDate"]
-
-            if repo_details["primaryLanguage"] is not None:
-                if curr_year not in yearly_data:
-                    yearly_data[curr_year] = dict()
-                if quarter not in yearly_data[curr_year]:
-                    yearly_data[curr_year][quarter] = dict()
-                if repo_details["primaryLanguage"]["name"] not in yearly_data[curr_year][quarter]:
-                    yearly_data[curr_year][quarter][repo_details["primaryLanguage"]["name"]] = {"add": 0, "del": 0}
-                yearly_data[curr_year][quarter][repo_details["primaryLanguage"]["name"]]["add"] += commit["additions"]
-                yearly_data[curr_year][quarter][repo_details["primaryLanguage"]["name"]]["del"] += commit["deletions"]
                 
     except Exception as e:
         DBM.w(f"\t\tError processing default branch {branch_name}: {str(e)}")

--- a/tests/test_commit_collection.py
+++ b/tests/test_commit_collection.py
@@ -511,6 +511,9 @@ def test_commit_cache_expires(tmp_path, monkeypatch):
 def test_commit_query_filters_by_github_user_identity():
     assert "author: {id: $authorId}" in GITHUB_API_QUERIES["repo_commit_list"]
     assert "defaultBranchRef" in GITHUB_API_QUERIES["user_repository_list"]
+    for query_name in ("repo_commit_list", "repo_commit_list_window"):
+        assert "additions" not in GITHUB_API_QUERIES[query_name]
+        assert "deletions" not in GITHUB_API_QUERIES[query_name]
 
 
 def test_collection_safety_budgets_are_bounded():


### PR DESCRIPTION
## Summary
- stop requesting per-commit additions and deletions that no rendered profile statistic consumes
- retain commit OID, timestamp, and linked author identity
- keep the bounded yearly 5xx fallback as defence in depth

## Evidence
- run 30218305934 showed the 2025 basilisk-C window timed out only with diff statistics included
- the same full-history query without additions/deletions succeeds immediately and paginates
- 54 tests pass; regression asserts both history queries stay free of unused diff fields