### PR TITLE
Timestamp successful commit crawls

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ bash runTestLocallyDocker.sh
 name: GitHub Stats Update
 on:
   schedule:
-    - cron: '0 3 * * *'  # Runs daily at 03:00 UTC
+    - cron: '17 3 * * *'  # Runs daily at 03:17 UTC
   workflow_dispatch:      # Allows manual trigger
 
 jobs:

--- a/sources/graphics_list_formatter.py
+++ b/sources/graphics_list_formatter.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, Tuple, List
+from typing import Dict, Tuple, List, Optional
 from datetime import datetime
 
 from pytz import timezone, utc
@@ -76,13 +76,19 @@ def make_list(data: List = None, names: List[str] = None, texts: List[str] = Non
     return "\n".join(data_list)
 
 
-async def make_commit_day_time_list(time_zone: str, repositories: Dict, commit_dates: Dict) -> str:
+async def make_commit_day_time_list(
+    time_zone: str,
+    repositories: Dict,
+    commit_dates: Dict,
+    crawl_completed_at: Optional[datetime] = None,
+) -> str:
     """
     Calculate commit-related info, how many commits were made, and at what time of day and day of week.
 
     :param time_zone: User time zone.
     :param repositories: User repositories list.
     :param commit_dates: User commit data list.
+    :param crawl_completed_at: Completion time for the successful crawl.
     :returns: string representation of statistics.
     """
     stats = str()
@@ -109,9 +115,17 @@ async def make_commit_day_time_list(time_zone: str, repositories: Dict, commit_d
 
     # Add total commits count if enabled
     if EM.SHOW_TOTAL_COMMITS:
+        completed_at = crawl_completed_at or datetime.now(utc)
+        if completed_at.tzinfo is None:
+            completed_at = utc.localize(completed_at)
+        local_completed_at = completed_at.astimezone(timezone(time_zone))
+        crawl_timestamp = (
+            f"{local_completed_at.day} "
+            f"{local_completed_at:%B %Y at %H:%M %Z}"
+        )
         stats += (
-            "**Accessible unique authored commits on repository default branches "
-            f"(last successful crawl): {total_commits}** \n\n"
+            "**Unique authored commits on repository default branches "
+            f"(last successful crawl on {crawl_timestamp}): {total_commits}** \n\n"
         )
 
     if EM.SHOW_COMMIT:

--- a/sources/main.py
+++ b/sources/main.py
@@ -41,10 +41,19 @@ async def get_stats() -> str:
     repositories = await collect_user_repositories(DM.target_username)
 
     if EM.SHOW_COMMIT or EM.SHOW_DAYS_OF_WEEK:
-        yearly_data, commit_data = await calculate_commit_data(repositories, DM.target_username)
+        yearly_data, commit_data, crawl_completed_at = await calculate_commit_data(
+            repositories,
+            DM.target_username,
+        )
         timezone = "UTC"  # Default to UTC since we don't need WakaTime for timezone
         DBM.i("Adding user commit day time info...")
-        stats += f"{await make_commit_day_time_list(timezone, repositories, commit_data)}\n\n"
+        commit_stats = await make_commit_day_time_list(
+            timezone,
+            repositories,
+            commit_data,
+            crawl_completed_at,
+        )
+        stats += f"{commit_stats}\n\n"
 
     DBM.i(f"Repository stats collection completed in {datetime.now() - start_time}")
     DBM.g("Stats for README collected!")

--- a/sources/manager_file.py
+++ b/sources/manager_file.py
@@ -204,11 +204,11 @@ class FileManager:
                     content = TokenManager.redact_sensitive_data(content)
                 
                 # Convert integer keys to strings for JSON serialization
-                if isinstance(content, list) and len(content) == 2:
-                    yearly_data, date_data = content
+                if isinstance(content, list) and len(content) in (2, 3):
+                    yearly_data = content[0]
                     if isinstance(yearly_data, dict):
                         yearly_data = {str(k): v for k, v in yearly_data.items()}
-                    content = [yearly_data, date_data]
+                    content = [yearly_data, *content[1:]]
                 
                 # Serialize data securely
                 json_data = json.dumps(content)
@@ -233,14 +233,14 @@ class FileManager:
                     data = json.loads(decrypted_data)
                     
                     # Convert string keys back to integers for yearly_data
-                    if isinstance(data, list) and len(data) == 2:
-                        yearly_data, date_data = data
+                    if isinstance(data, list) and len(data) in (2, 3):
+                        yearly_data = data[0]
                         if isinstance(yearly_data, dict):
                             yearly_data = {
                                 int(k) if k.isdigit() else k: v 
                                 for k, v in yearly_data.items()
                             }
-                            data = [yearly_data, date_data]
+                            data = [yearly_data, *data[1:]]
                     return data
                 except InvalidToken:
                     return None

--- a/sources/yearly_commit_calculator.py
+++ b/sources/yearly_commit_calculator.py
@@ -1,5 +1,5 @@
 from asyncio import sleep
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Tuple, List, Set
 import os
 from hashlib import sha256
@@ -10,7 +10,7 @@ from .manager_file import FileManager as FM
 from .manager_debug import DebugManager as DBM
 
 COMMIT_CACHE_MAX_AGE_SECONDS = 36 * 60 * 60
-CACHE_SCHEMA_VERSION = 3
+CACHE_SCHEMA_VERSION = 4
 
 
 def ensure_cache_dir():
@@ -20,13 +20,16 @@ def ensure_cache_dir():
     return cache_dir
 
 
-async def calculate_commit_data(repositories: List[Dict], target_username: str) -> Tuple[Dict, Dict]:
+async def calculate_commit_data(
+    repositories: List[Dict],
+    target_username: str,
+) -> Tuple[Dict, Dict, datetime]:
     """
     Calculate authored commit timestamps with secure local caching.
 
     :param repositories: user repositories info dictionary.
     :param target_username: GitHub username of the authenticated user.
-    :returns: Commit quarter yearly data dictionary.
+    :returns: Yearly data, commit timestamps, and successful crawl completion time.
     """
     DBM.i("Calculating commit data...")
     cache_enabled = os.getenv("GITHUB_ACTIONS", "").lower() != "true"
@@ -49,16 +52,20 @@ async def calculate_commit_data(repositories: List[Dict], target_username: str) 
                 max_age_seconds=COMMIT_CACHE_MAX_AGE_SECONDS,
             )
             if cached_data is not None:
-                yearly_data, date_data = cached_data
+                yearly_data, date_data, completed_at_value = cached_data
                 
                 # Validate cache structure without using string operations
                 if (isinstance(yearly_data, dict) and
                     isinstance(date_data, dict) and
+                    isinstance(completed_at_value, str) and
                     all(isinstance(v, dict) for v in yearly_data.values()) and
                     all(isinstance(v, dict) for v in date_data.values())):
 
+                    completed_at = datetime.fromisoformat(completed_at_value)
+                    if completed_at.tzinfo is None:
+                        raise ValueError("Cached crawl completion time has no timezone")
                     DBM.i("Commit data restored from cache!")
-                    return yearly_data, date_data
+                    return yearly_data, date_data, completed_at
                 else:
                     DBM.w("Cache data validation failed - fetching fresh data")
         except Exception as e:
@@ -91,13 +98,18 @@ async def calculate_commit_data(repositories: List[Dict], target_username: str) 
         )
     
     DBM.i("Commit data calculated!")
+    completed_at = datetime.now(timezone.utc)
     
     if cache_enabled:
         # Cache the data for this specific username during local development.
-        FM.cache_binary(cache_filename, [yearly_data, date_data], assets=True)
+        FM.cache_binary(
+            cache_filename,
+            [yearly_data, date_data, completed_at.isoformat()],
+            assets=True,
+        )
         DBM.i("New commit data saved to cache!")
     
-    return yearly_data, date_data
+    return yearly_data, date_data, completed_at
 
 
 def repository_key(repo_details: Dict) -> str:

--- a/tests/test_commit_collection.py
+++ b/tests/test_commit_collection.py
@@ -294,10 +294,15 @@ async def test_default_branch_history_deduplicates_across_forks():
     with patch.object(EnvironmentManager, "SHOW_TOTAL_COMMITS", True), patch.object(
         EnvironmentManager, "SHOW_COMMIT", False
     ), patch.object(EnvironmentManager, "SHOW_DAYS_OF_WEEK", False):
-        output = await make_commit_day_time_list("UTC", repositories, date_data)
+        output = await make_commit_day_time_list(
+            "UTC",
+            repositories,
+            date_data,
+            datetime.fromisoformat("2026-07-27T06:24:00+00:00"),
+        )
     assert (
-        "Accessible unique authored commits on repository default branches "
-        "(last successful crawl): 3"
+        "**Unique authored commits on repository default branches "
+        "(last successful crawl on 27 July 2026 at 06:24 UTC): 3**"
     ) in output
 
 

--- a/tests/test_commit_collection.py
+++ b/tests/test_commit_collection.py
@@ -449,6 +449,33 @@ async def test_github_actions_runner_does_not_read_or_write_commit_cache():
 
 
 @pytest.mark.asyncio
+async def test_cached_commit_data_preserves_crawl_completion_time():
+    cached_at = "2026-07-26T03:17:00+00:00"
+    cached_data = [{}, {}, cached_at]
+
+    with patch.dict("os.environ", {"GITHUB_ACTIONS": ""}), patch(
+        "sources.yearly_commit_calculator.ensure_cache_dir"
+    ), patch.object(
+        FileManager,
+        "cache_binary",
+        return_value=cached_data,
+    ), patch.object(
+        DownloadManager,
+        "get_remote_graphql",
+        new=AsyncMock(),
+    ) as graphql:
+        yearly_data, date_data, completed_at = await calculate_commit_data(
+            [],
+            "VatsalSy",
+        )
+
+    assert yearly_data == {}
+    assert date_data == {}
+    assert completed_at.isoformat() == cached_at
+    graphql.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_pagination_rejects_missing_next_cursor():
     page = {
         "data": {
@@ -541,6 +568,20 @@ def test_commit_cache_expires(tmp_path, monkeypatch):
             )
             is None
         )
+
+
+def test_commit_cache_round_trip_preserves_completion_time(tmp_path, monkeypatch):
+    monkeypatch.setattr(FileManager, "ASSETS_DIR", str(tmp_path))
+    monkeypatch.setattr(FileManager, "_ENCRYPTION_KEY", None)
+    cached_data = [
+        {2026: {"commits": 1}},
+        {"owner/repo": {}},
+        "2026-07-26T03:17:00+00:00",
+    ]
+
+    FileManager.cache_binary("commits.json", cached_data, assets=True)
+
+    assert FileManager.cache_binary("commits.json", assets=True) == cached_data
 
 
 def test_commit_query_filters_by_github_user_identity():


### PR DESCRIPTION
## What changed

- records the completion time only after the full default-branch crawl succeeds
- persists and reuses the original completion time for secure local cache hits
- renders the unique authored commit count with an explicit UTC date and time
- updates the documented daily schedule to 03:17 UTC
- adds deterministic fresh-output, cache-hit, and cache-round-trip regressions

## Why

The profile should show when its count was last refreshed successfully, without making cached data look fresh, and the example schedule should avoid GitHub's congested top-of-hour window.

## Validation

- `PYTHONPATH=. venv/bin/pytest -q` — 56 passed
- `venv/bin/pre-commit run --all-files` — passed
- `git diff --check`
- `python3 -m compileall -q sources tests`